### PR TITLE
docs: update proposal workflow with zero point gate

### DIFF
--- a/.agent/workflows/openspec-proposal.md
+++ b/.agent/workflows/openspec-proposal.md
@@ -10,7 +10,11 @@ description: Scaffold a new OpenSpec change and validate strictly.
 - Do not write any code during the proposal stage. Only create design documents (proposal.md, tasks.md, design.md, and spec deltas). Implementation happens in the apply stage after approval.
 
 **Steps**
-0. **Git Workflow Gate**: Before creating a new proposal, run `openspec list` and check for any active (non-archived) changes in `openspec/changes/`. If an active change exists, STOP and inform the user: "Cannot create new proposal — active change `<id>` must be archived first." Only proceed if no active changes exist.
+0. **Zero Point Gate**: Ensure the workspace is clean before starting.
+   a. Check out `master` and pull latest changes: `git checkout master && git pull`.
+   b. Ensure no local feature/spec branches exist. Run `git branch` to list local branches. If any branches other than `master` exist, ask the user to delete them or confirm they are safe to keep.
+   c. Run `openspec list` and check for any active (non-archived) changes in `openspec/changes/`. If an active change exists, STOP and inform the user: "Cannot create new proposal — active change `<id>` must be archived first."
+   Only proceed if these conditions are met.
 1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
 2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
 3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.


### PR DESCRIPTION
Enforces the "Zero Point Gate" in the OpenSpec proposal workflow. This ensures that:
1.  Master is synced.
2.  No stale local branches exist.
3.  No active OpenSpec proposals exist (must execute one at a time).