### PR TITLE
fix: include workflow definitions in ci triggers

### DIFF
--- a/.github/workflows/backend-notification-service.yml
+++ b/.github/workflows/backend-notification-service.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - 'src/backend/notification-service/**'
       - 'Directory.Build.props'
+      - '.github/workflows/backend-notification-service.yml'
+      - '.github/workflows/templates/dotnet-ci.yml'
   push:
     branches:
       - master
     paths:
       - 'src/backend/notification-service/**'
       - 'Directory.Build.props'
+      - '.github/workflows/backend-notification-service.yml'
+      - '.github/workflows/templates/dotnet-ci.yml'
 
 jobs:
   ci:


### PR DESCRIPTION
This PR updates the CI triggers to include changes to `.github/workflows/**`. 
Previously, modifying the CI definition itself did not trigger the validation for the service, leading to skipped checks when strictly CI logic was updated.
Strictly monitoring these paths ensures we always validate the pipeline changes against the code.