### PR TITLE
test: trigger ci check for branch protection visibility

### DIFF
--- a/TEST_CI_TRIGGER.md
+++ b/TEST_CI_TRIGGER.md
@@ -1,0 +1,5 @@
+# Test File
+
+This file is created solely to trigger the CI workflow and make the `monorepo-gate` check visible in GitHub's branch protection settings.
+
+Once the check appears in Settings, this PR can be closed without merging.


### PR DESCRIPTION
This is a test PR to trigger the CI workflow and make the `Monorepo CI Gate / monorepo-gate` check visible in GitHub's branch protection settings.

Once the check appears in Settings → Branches → master, this PR can be closed without merging.