### PR TITLE
test: verify build failure blocks merge

### DIFF
--- a/src/backend/notification-service/NotificationService/Program.cs
+++ b/src/backend/notification-service/NotificationService/Program.cs
@@ -11,4 +11,7 @@ app.ConfigurePipeline();
 
 app.Run();
 
+// INTENTIONAL SYNTAX ERROR TO TEST BUILD GATE
+ThisWillNotCompile();
+
 public partial class Program { }


### PR DESCRIPTION
**Test Case 1: Build Failure**

This PR intentionally introduces a compilation error to verify that the CI gate blocks merging when the build fails.

Expected: The `monorepo-gate` check should FAIL and the "Merge" button should be disabled.