### PR TITLE
fix: revert broken build from test

### DIFF
--- a/src/backend/notification-service/NotificationService/Program.cs
+++ b/src/backend/notification-service/NotificationService/Program.cs
@@ -11,7 +11,4 @@ app.ConfigurePipeline();
 
 app.Run();
 
-// INTENTIONAL SYNTAX ERROR TO TEST BUILD GATE
-ThisWillNotCompile();
-
 public partial class Program { }


### PR DESCRIPTION
This PR reverts the broken build that was accidentally merged in PR #13.

**Root Cause**: The branch protection rule for `monorepo-gate` was not properly configured or the check hadn't completed before merge.

This fix removes the syntax error and restores master to a working state.