### PR TITLE
test: validate ci gate blocks merge on build failure

### DIFF
--- a/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
+++ b/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
@@ -50,4 +50,11 @@ public class NotificationDispatcherTests
         await act.Should().NotThrowAsync();
         await _provider2.Received(1).SendAsync(request, Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public void TestGate_ShouldFail_ToValidateCIBlocking()
+    {
+        // This test intentionally fails to verify CI blocks merge
+        Assert.True(false, "TEST: This failure should block merge");
+    }
 }

--- a/src/backend/notification-service/NotificationService/Program.cs
+++ b/src/backend/notification-service/NotificationService/Program.cs
@@ -11,10 +11,4 @@ app.ConfigurePipeline();
 
 app.Run();
 
-// TEST: This should cause build to fail and block merge
-var undeclaredVariable = nonExistentMethod();
-
-// INTENTIONAL SYNTAX ERROR TO TEST BUILD GATE
-ThisWillNotCompile();
-
 public partial class Program { }


### PR DESCRIPTION
**CI Gate Validation Test**

This PR intentionally introduces a compilation error to verify that:
1. ✅ The CI build fails
2. ✅ The `monorepo-gate` check reports failure
3. ✅ The "Merge pull request" button is **DISABLED**
4. ✅ A message appears: "Required status check 'monorepo-gate' has not succeeded"

**Expected Behavior**: You should NOT be able to merge this PR until the build is fixed.

**To verify**: Check that the merge button is disabled/grayed out after the CI runs.