### PR TITLE
test: verify gate blocks merge on test failure

### DIFF
--- a/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
+++ b/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
@@ -50,4 +50,11 @@ public class NotificationDispatcherTests
         await act.Should().NotThrowAsync();
         await _provider2.Received(1).SendAsync(request, Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public void Gate_ShouldBlock_WhenTestFails()
+    {
+        // This test intentionally fails to verify CI gate blocks merge
+        Assert.True(false, "GATE TEST: This failure should block merge");
+    }
 }


### PR DESCRIPTION
**Test: Verify CI Gate Blocks Merge**

This PR contains a failing test to verify that the `monorepo-gate` check properly blocks merging.

**Expected Behavior:**
- ❌ The `monorepo-gate` check should **FAIL**
- 🚫 The "Merge pull request" button should be **DISABLED/GRAYED OUT**
- 📝 A message should appear: "Merging is blocked - Required status check 'monorepo-gate' has not succeeded"

**If the merge button is enabled**, the branch protection is still not working correctly.

**Do NOT merge this PR** - it's only for testing. Close it after verification.