### PR TITLE
fix: rename workflow to match branch protection check name

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,4 +1,4 @@
-name: Monorepo CI Gate
+name: monorepo-gate
 
 on:
   pull_request:


### PR DESCRIPTION
**Fix: Rename Workflow to Match Branch Protection**

## Problem
Branch protection requires the check name to match **exactly**. Currently:
- Workflow name: `Monorepo CI Gate`
- GitHub reports check as: `Monorepo CI Gate / monorepo-gate (pull_request)`
- Branch protection expects: `monorepo-gate`

This mismatch prevents branch protection from enforcing the check.

## Solution
Rename the workflow from `Monorepo CI Gate` to just `monorepo-gate` so the check name matches exactly what's configured in branch protection.

## Expected Result
After merging, the check should appear as just `monorepo-gate` and branch protection will properly block PRs when it fails.