### PR TITLE
test: verify per-service CI blocks merge (MUST WORK)

### DIFF
--- a/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
+++ b/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
@@ -50,4 +50,11 @@ public class NotificationDispatcherTests
         await act.Should().NotThrowAsync();
         await _provider2.Received(1).SendAsync(request, Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public void CI_MustBlock_WhenTestFails()
+    {
+        // This test MUST fail and CI MUST block merge
+        Assert.Fail("CI GATE TEST: Merge must be blocked");
+    }
 }


### PR DESCRIPTION
**FINAL TEST: Verify Per-Service CI Blocks Merge**

This PR tests the industry-standard per-service CI workflow pattern.

**Expected Behavior:**
- ❌ `Notification Service CI / validate` check **FAILS**
- 🚫 **Merge button is DISABLED** (branch protection enforced)
- ✅ Message: "Merging is blocked"

**This MUST work** - it's the proven pattern used by all major monorepos.

**DO NOT MERGE** - Close after verification.