### PR TITLE
fix: rename workflow to bypass GitHub check cache

### DIFF
--- a/.github/workflows/notification-service-ci.yml
+++ b/.github/workflows/notification-service-ci.yml
@@ -1,4 +1,4 @@
-name: Notification Service CI
+name: notification-service-quality-gate
 
 on:
   pull_request:


### PR DESCRIPTION
**Fix: Rename Workflow to Bypass GitHub Check Cache**

## Problem
GitHub caches check names for 7 days. The old check names (`check-notification-service`, etc.) are still appearing in branch protection settings even though those workflows were deleted.

## Solution
Rename the workflow to a completely unique name: `notification-service-quality-gate`

This will create a fresh check name that:
- Has never been used before
- Will appear in branch protection dropdown immediately
- Can be properly enforced

## After Merging
1. Wait for this PR's CI to run
2. Go to branch protection settings
3. Search for `notification-service-quality-gate` or `validate`
4. The new check should appear and be selectable
5. Add it as a required check