### PR TITLE
chore: restore green state by removing failing trigger test

### DIFF
--- a/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
+++ b/src/backend/notification-service/NotificationService.Tests/Unit/NotificationDispatcherTests.cs
@@ -50,11 +50,4 @@ public class NotificationDispatcherTests
         await act.Should().NotThrowAsync();
         await _provider2.Received(1).SendAsync(request, Arg.Any<CancellationToken>());
     }
-
-    [Fact]
-    public void MonorepoGate_MustBlock_OnFailure()
-    {
-        // This test MUST fail
-        Assert.Fail("MONOREPO GATE TEST: Merge must be blocked by branch protection");
-    }
 }


### PR DESCRIPTION
Restoring master to a green state. This will also allow us to verify the CI gate passes correctly.