### PR TITLE
fix: restore master to green state

### DIFF
--- a/src/backend/notification-service/NotificationService/Program.cs
+++ b/src/backend/notification-service/NotificationService/Program.cs
@@ -1,4 +1,4 @@
-usiiing Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using NotificationService.Bootstrap;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
**Objective**: Restore master to a green state after it was accidentally broken during QA testing.

**Fix**: Corrected the `usiiing` typo in `Program.cs`.