### PR TITLE
fix(ci): add checkout step for paths-filter on push events

### DIFF
--- a/.github/workflows/notification-service-ci.yml
+++ b/.github/workflows/notification-service-ci.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       service: ${{ steps.filter.outputs.service }}
     steps:
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
       id: filter
       with:


### PR DESCRIPTION
## Summary
Fix CI workflow failure caused by missing checkout step in the paths-filter job.

## Why
The `dorny/paths-filter@v2` action **requires a checkout step when triggered by push events**:
- On `pull_request` events: It uses GitHub API to get file changes (no checkout needed)
- On `push` events: It needs git history to compare commits (checkout required)

This was causing CI failures on every push to master with the error showing the `changes` job failing in 2 seconds.

## What Changes
Added `actions/checkout@v4` step before `dorny/paths-filter@v2` in the `changes` job.

```yaml
steps:
- uses: actions/checkout@v4      # ← Added this
- uses: dorny/paths-filter@v2
```

## Impact
- Fixes CI workflow failures on push to master
- Stops failure notification emails
- No functional changes to the validation logic