### PR TITLE
fix(cd): use service name for reliable Railway deployment

### DIFF
--- a/.github/workflows/notification-service-ci.yml
+++ b/.github/workflows/notification-service-ci.yml
@@ -45,7 +45,9 @@ jobs:
       # If changes detected (true), bypass is false. If no changes (false), bypass is true.
       bypass_checks: ${{ needs.changes.outputs.service != 'true' }}
       enable_deploy: true
+      railway_service_name: 'notification-service'
     secrets: inherit
+
 
 
 

--- a/.github/workflows/template-dotnet-ci.yml
+++ b/.github/workflows/template-dotnet-ci.yml
@@ -23,7 +23,12 @@ on:
         type: boolean
         default: false
         description: "If true, enables the deployment job."
+      railway_service_name:
+        required: false
+        type: string
+        description: "The name of the service in Railway (e.g., notification-service)."
     secrets:
+
 
       RAILWAY_TOKEN:
         required: false
@@ -111,10 +116,16 @@ jobs:
       - name: Install Railway CLI
         run: npm i -g @railway/cli
 
+      - name: Check Railway Status
+        run: railway status
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
       - name: Deploy to Railway
-        run: railway up --service ${{ secrets.RAILWAY_SERVICE_ID }} -d
+        run: railway up --service ${{ inputs.railway_service_name }} -d
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         working-directory: ${{ inputs.project_path }}
+
 
 


### PR DESCRIPTION
## Summary
Fix for "Service not found" error during automated deployment.

## Why
The previous deployment attempt failed because the Railway CLI couldn't resolve the service by UUID in the CI environment.

## What Changes
1. **Name-based Deployment**: Switched `railway up --service` to use the service name (`notification-service`) instead of the UUID.
2. **Observability**: Added `railway status` before the deployment step to verify project and environment links.
3. **Template Update**: Added `railway_service_name` input to the reusable template.

## Verification
- Merge this fix and observe the deployment job on `master`.
- Verify the `Check Railway Status` step output.