### PR TITLE
fix(cd): add explicit build config for Railway Railpack

### DIFF
--- a/src/backend/notification-service/railway.json
+++ b/src/backend/notification-service/railway.json
@@ -1,8 +1,13 @@
 {
     "$schema": "https://railway.com/railway.schema.json",
+    "build": {
+        "builder": "NIXPACKS",
+        "buildCommand": "dotnet publish NotificationService/NotificationService.csproj -c Release -o out"
+    },
     "deploy": {
-        "startCommand": "dotnet NotificationService.dll --urls http://*:$PORT",
+        "startCommand": "dotnet out/NotificationService.dll --urls http://*:$PORT",
         "healthcheckPath": "/health",
-        "healthcheckTimeout": 30
+        "healthcheckTimeout": 60,
+        "restartPolicyType": "ON_FAILURE"
     }
 }


### PR DESCRIPTION
## Summary
Fix for Railway Railpack failing to detect the .NET 10 project structure.

## Why
Railpack couldn't determine the build strategy for the `notification-service` because the `.csproj` is in a subdirectory and .NET 10 is very recent. It defaulted to looking for a `start.sh` which was missing.

## What Changes
1. **Explicit Build**: Added a `build` section to `railway.json` using the `NIXPACKS` builder.
2. **Explicit Publish**: Defined the `buildCommand` as `dotnet publish NotificationService/NotificationService.csproj -c Release -o out`.
3. **Point to DLL**: Updated `startCommand` to point to the entry point in the `out` directory.
4. **Resiliency**: Increased healthcheck timeout to 60s and added an `ON_FAILURE` restart policy.

## Verification
- Merge to master.
- Check Railway build logs to verify `dotnet publish` executes correctly.
- Verify the service starts up using the DLL in the `out` folder.