### PR TITLE
fix(cd): use Docker for reliable .NET 10 deployment

### DIFF
--- a/.github/workflows/template-dotnet-ci.yml
+++ b/.github/workflows/template-dotnet-ci.yml
@@ -113,6 +113,12 @@ jobs:
         with:
           fetch-depth: 0 # Needed for automated versioning and tags later
 
+      - name: Prepare Monorepo Context
+        run: |
+          cp -f Directory.Build.props ${{ inputs.project_path }}/ 2>/dev/null || true
+          cp -f global.json ${{ inputs.project_path }}/ 2>/dev/null || true
+
+
       - name: Install Railway CLI
         run: npm i -g @railway/cli
 

--- a/src/backend/notification-service/Dockerfile
+++ b/src/backend/notification-service/Dockerfile
@@ -1,0 +1,25 @@
+# Build Stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy the shared properties and global config if they exist in the build context
+# Note: These will be copied from the local directory by the CLI
+COPY Directory.Build.props* ./
+COPY global.json* ./
+
+# Copy the service code
+COPY . .
+
+# Publish the service
+RUN dotnet publish NotificationService/NotificationService.csproj -c Release -o /app
+
+# Runtime Stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app .
+
+# Railway provides the PORT environment variable
+ENV PORT=8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "NotificationService.dll", "--urls", "http://*:$PORT"]

--- a/src/backend/notification-service/railway.json
+++ b/src/backend/notification-service/railway.json
@@ -1,11 +1,7 @@
 {
     "$schema": "https://railway.com/railway.schema.json",
-    "build": {
-        "builder": "NIXPACKS",
-        "buildCommand": "dotnet publish NotificationService/NotificationService.csproj -c Release -o out"
-    },
     "deploy": {
-        "startCommand": "dotnet out/NotificationService.dll --urls http://*:$PORT",
+        "startCommand": "dotnet NotificationService.dll",
         "healthcheckPath": "/health",
         "healthcheckTimeout": 60,
         "restartPolicyType": "ON_FAILURE"


### PR DESCRIPTION
## Summary
Fix for .NET 10 build failures on Railway by switching to a Docker-based deployment.

## Why
Railway's auto-detection (Nixpacks/Railpack) was defaulting to .NET 6, which doesn't support .NET 10 features or the shared `Directory.Build.props` structure used in this monorepo.

## What Changes
1. **Dockerfile Integration**: Added a production-ready `Dockerfile` using the official Microsoft .NET 10 SDK and ASP.NET runtime images.
2. **Context Injection**: Updated the GitHub workflow to inject `Directory.Build.props` and `global.json` into the service folder before deployment. This ensures the Docker build has all the necessary shared configurations.
3. **Railway Config**: Simplified `railway.json` to leverage the Dockerfile for building while retaining healthcheck and restart policies.
4. **Hermetic Build**: The build now happens entirely inside the Docker container, ensuring consistent SDK versions.

## Verification
- Merge to master.
- Check Railway build logs—it should now clearly show "Building Docker Context" and use the .NET 10 SDK.
- Healthchecks should pass once the container starts.