### PR TITLE
fix(cd): use Project-Access-Token header for Railway GraphQL API

### DIFF
--- a/.github/workflows/template-dotnet-ci.yml
+++ b/.github/workflows/template-dotnet-ci.yml
@@ -166,7 +166,7 @@ jobs:
             # Fallback: Query latest deployment via GraphQL API
             LATEST_DEPLOY_QUERY='{"query": "query { service(id: \"'${{ secrets.RAILWAY_SERVICE_ID }}'\") { latestDeployment { id status } } }"}'
             LATEST_DEPLOY_RESPONSE=$(curl -s -X POST https://backboard.railway.com/graphql/v2 \
-              -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
+              -H "Project-Access-Token: ${{ secrets.RAILWAY_TOKEN }}" \
               -H "Content-Type: application/json" \
               -d "$LATEST_DEPLOY_QUERY")
             
@@ -198,7 +198,7 @@ jobs:
             # Query deployment status via GraphQL API
             GRAPHQL_QUERY='{"query": "query { deployment(id: \"'$DEPLOYMENT_ID'\") { id status } }"}'
             GRAPHQL_RESPONSE=$(curl -s -X POST https://backboard.railway.com/graphql/v2 \
-              -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
+              -H "Project-Access-Token: ${{ secrets.RAILWAY_TOKEN }}" \
               -H "Content-Type: application/json" \
               -d "$GRAPHQL_QUERY")
             

--- a/openspec/changes/add-continuous-delivery/design.md
+++ b/openspec/changes/add-continuous-delivery/design.md
@@ -265,7 +265,7 @@ jobs:
 - Use `--detach --json` flags to trigger deployment and capture deployment ID
 - **Wait-and-Verify via GraphQL API**: Poll Railway's GraphQL API for deployment status
   - Endpoint: `https://backboard.railway.com/graphql/v2`
-  - Authentication: `Authorization: Bearer $RAILWAY_TOKEN` header
+  - Authentication: `Project-Access-Token: $RAILWAY_TOKEN` header (required for project tokens)
   - Query deployment status using deployment ID from `railway up --json` output
   - Poll every 5 seconds, timeout after 5 minutes (60 attempts)
   - Success states: `SUCCESS`, `ACTIVE` (Railway only sets these after health checks pass)
@@ -661,7 +661,7 @@ git commit -m "chore($SERVICE): release v$VERSION [skip ci]"
 ```bash
 # Query deployment status via GraphQL API
 curl -X POST https://backboard.railway.com/graphql/v2 \
-  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "query { deployment(id: \"<deployment_id>\") { status } }"}'
 ```

--- a/openspec/changes/add-continuous-delivery/specs/spec.md
+++ b/openspec/changes/add-continuous-delivery/specs/spec.md
@@ -336,7 +336,7 @@ The deployment process SHALL explicitly wait for and verify successful deploymen
 
 #### Scenario: Deployment Status Polling Configuration
 - **WHEN** polling Railway's GraphQL API for deployment status
-- **THEN** the workflow SHALL use the Railway project token for authentication via `Authorization: Bearer <token>` header
+- **THEN** the workflow SHALL use the Railway project token for authentication via `Project-Access-Token: <token>` header
 - **AND** it SHALL poll at 5-second intervals to balance responsiveness with API rate limits
 - **AND** it SHALL timeout after 5 minutes (60 attempts) if deployment does not reach a terminal state
 - **AND** on timeout, it SHALL fail the CI job and display recent deployment logs

--- a/openspec/changes/add-continuous-delivery/tasks.md
+++ b/openspec/changes/add-continuous-delivery/tasks.md
@@ -214,7 +214,7 @@
   - **Verify**: Step outputs deployment ID (with fallback to querying latest deployment)
 - [x] 3.4.2 Implement polling loop to check deployment status via Railway GraphQL API
   - **Verify**: Loop polls `https://backboard.railway.com/graphql/v2` for deployment status
-  - **Verify**: Uses `Authorization: Bearer $RAILWAY_TOKEN` header for authentication
+  - **Verify**: Uses `Project-Access-Token: $RAILWAY_TOKEN` header for authentication (required for project tokens)
   - **Verify**: Queries deployment object by ID: `query { deployment(id: "<id>") { status } }`
 - [x] 3.4.3 Fail job if deployment status becomes `FAILED`, `CRASHED`, or `REMOVED`
   - **Verify**: CI job fails on terminal failure states


### PR DESCRIPTION
## Summary

Fixes the "Not Authorized" error when polling Railway GraphQL API for deployment status.

## Problem

The previous implementation used `Authorization: Bearer <token>` header, but **Railway project tokens require `Project-Access-Token: <token>` header** for GraphQL API authentication.

Error observed:
```json
{"errors":[{"message":"Not Authorized","path":["deployment"]}],"data":null}
```

## Fix

Changed the authentication header from:
```
-H "Authorization: Bearer $RAILWAY_TOKEN"
```
to:
```
-H "Project-Access-Token: $RAILWAY_TOKEN"
```

## Changes

- `.github/workflows/template-dotnet-ci.yml` - Fixed both GraphQL curl requests
- `openspec/.../spec.md` - Updated authentication requirement
- `openspec/.../design.md` - Updated implementation details and example
- `openspec/.../tasks.md` - Updated verification criteria

## Testing

After merge, the deployment verification should successfully:
1. Poll Railway GraphQL API for deployment status
2. Display status updates: `BUILDING` → `DEPLOYING` → `SUCCESS`/`ACTIVE`
3. Complete successfully when health checks pass