### PR TITLE
fix(logs): improve readability and document port binding strategy

### DIFF
--- a/src/backend/notification-service/NotificationService/NotificationService.csproj
+++ b/src/backend/notification-service/NotificationService/NotificationService.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Telegram.Bot" Version="22.8.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/backend/notification-service/NotificationService/appsettings.json
+++ b/src/backend/notification-service/NotificationService/appsettings.json
@@ -25,10 +25,14 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
         }
       }
     ],
-    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"]
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName",
+      "WithThreadId"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

This PR addresses two final polishing items from Phase 3:
1. **Readable Logs**: Switched Serilog to `RenderedCompactJsonFormatter` so Railway logs show readable messages.
2. **Comprehensive Documentation**: Documented the "Zero-Config" port binding strategy and the lessons learned with `$PORT` expansion.

## Technical Changes

### Serilog Polishing
- Added `Serilog.Formatting.Compact` package.
- Updated `appsettings.json` to use `RenderedCompactJsonFormatter`.
- **Why**: The legacy `JsonFormatter` excluded the rendered message string, making logs hard to read in generic viewers like the Railway dashboard.

### Documentation Updates
- Added **Decision 22** in `design.md`: "Port Binding Strategy for Modern .NET and Railway".
- Explicitly documented the root cause of the earlier failures (lack of shell expansion for `$PORT` in `startCommand`).
- Formalized the "Zero-Config" approach (omitting `--urls` flag) as the preferred solution.
- Cleaned up documentation structure around deployment verification.

## Testing

- Local build of `NotificationService` succeeds with new package.
- Documentation reviewed for clarity and accuracy.
- Deployment to Railway was previously verified successful with the "Zero-Config" approach; this PR just documentation and formatting on top.
