### PR TITLE
fix(logs): optimize JSON structure for Railway viewer

### DIFF
--- a/src/backend/notification-service/NotificationService/NotificationService.csproj
+++ b/src/backend/notification-service/NotificationService/NotificationService.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Telegram.Bot" Version="22.8.1" />
   </ItemGroup>

--- a/src/backend/notification-service/NotificationService/appsettings.json
+++ b/src/backend/notification-service/NotificationService/appsettings.json
@@ -25,7 +25,10 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+          "formatter": {
+            "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+            "template": "{ {timestamp: @t, level: @l, message: @m, ..@p} }\n"
+          }
         }
       }
     ],


### PR DESCRIPTION
## Summary

Optimizes the JSON log format specifically for the Railway log viewer.

## The Problem

While `RenderedCompactJsonFormatter` included the message, it used the `@m` key (CLEF format). Railway's log aggregator does not recognize `@m` as the primary message, causing:
1. The "Message" column in the UI to be empty.
2. The entire record to be wrapped in a generic "attributes" field.

## The Fix

Implemented a custom JSON structure using `Serilog.Expressions`:
- Mapped `@m` (rendered message) to `message`.
- Mapped `@t` (timestamp) to `timestamp`.
- Mapped `@l` (level) to `level`.
- Included all other properties at the root level.

## Result

Railway should now correctly parse the JSON and display the log message directly in the main view, making the logs "great" again. 🎉