### PR TITLE
fix: correct Versionize CLI arguments in CI template

### DIFF
--- a/.github/workflows/template-dotnet-ci.yml
+++ b/.github/workflows/template-dotnet-ci.yml
@@ -127,12 +127,11 @@ jobs:
           # --exit-insignificant-commits: exits with non-zero if no changes
           # --workingDir: filter commits by path
           # --tag-template: format for the git tag
-          # --commit-message-template: format for the commit message
+          # --commit-suffix: add skip ci to the commit message
           if versionize \
-            --workingRoot . \
             --workingDir ${{ inputs.project_path }} \
             --tag-template "${{ inputs.railway_service_name }}/v" \
-            --commit-message-template "chore(${{ inputs.railway_service_name }}): release v{version} [skip ci]" \
+            --commit-suffix " [skip ci]" \
             --exit-insignificant-commits; then
             echo "version_bumped=true" >> $GITHUB_OUTPUT
             


### PR DESCRIPTION
## Summary
This fix addresses the failures in the CD pipeline caused by incorrect `Versionize` CLI arguments.

## Fixes
- Removed the unsupported `--workingRoot` argument.
- Replaced the unsupported `--commit-message-template` with `--commit-suffix " [skip ci]"`. This ensures automated commits still include the skip marker while using the tool's default message format.

## Verification
Verified locally using `versionize --dry-run` with these exact flags:
```bash
versionize --workingDir src/backend/notification-service --tag-template "notification-service/v" --commit-suffix " [skip ci]" --exit-insignificant-commits
```
Output confirmed the tool successfully identified the project and prepared the version/changelog update.