### PR TITLE
fix: correct Versionize tag template and placeholder

### DIFF
--- a/.github/workflows/template-dotnet-ci.yml
+++ b/.github/workflows/template-dotnet-ci.yml
@@ -130,7 +130,7 @@ jobs:
           # --commit-suffix: add skip ci to the commit message
           if versionize \
             --workingDir ${{ inputs.project_path }} \
-            --tag-template "${{ inputs.railway_service_name }}/v" \
+            --tag-template "${{ inputs.railway_service_name }}/v{version}" \
             --commit-suffix " [skip ci]" \
             --exit-insignificant-commits; then
             echo "version_bumped=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
This fix addresses two issues discovered during the first live run on `master`:
1.  **Tag Template**: Fixed the `Versionize` tag template to include the required `{version}` placeholder. Without this, the tool was creating tags named exactly "notification-service/v" instead of "notification-service/v1.0.0".
2.  **Workflow Resiliency**: This PR prepares the code for the next attempt.

## Required Action for User
To allow the automated version bump to be pushed to `master`, you **MUST** update the repository Ruleset bypass list as described in the issue discussion (Add "GitHub Actions" to bypass list for the `master` ruleset).

## Tag Cleanup
After merging this, it is recommended to delete the malformed tag:
```bash
git push origin :refs/tags/notification-service/v
```