### PR TITLE
fix: use PAT_TOKEN for CD branch protection bypass

### DIFF
--- a/.github/workflows/template-dotnet-ci.yml
+++ b/.github/workflows/template-dotnet-ci.yml
@@ -35,7 +35,9 @@ on:
       RAILWAY_TOKEN:
         required: false
         description: "The Railway Project Token."
-
+      PAT_TOKEN:
+        required: false
+        description: "Personal Access Token for bypassing branch protection."
 
 
 jobs:
@@ -111,6 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed for automated versioning and tags
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install Versionize
         run: dotnet tool install --global Versionize


### PR DESCRIPTION
## Summary
This fix enables the CD pipeline to bypass strict branch protection rules on `master` by using a Personal Access Token (PAT).

## Changes
- Updated `template-dotnet-ci.yml` to accept an optional `PAT_TOKEN` secret.
- Configured the `actions/checkout` step in the `deploy` job to use `${{ secrets.PAT_TOKEN }}`. When this token is used, `git push` operations will act as the user who generated the token, bypassing "PR Required" and "Status Check" rules.

## Setup Required
1. Ensure `PAT_TOKEN` is added to the repository secrets.
2. Once this PR is merged, the next run on `master` will use the PAT for versioning and tagging.
