### PR TITLE
fix: resolve missing logs in Railway by correcting Serilog config

### DIFF
--- a/src/backend/notification-service/NotificationService/appsettings.json
+++ b/src/backend/notification-service/NotificationService/appsettings.json
@@ -15,6 +15,10 @@
     "ChatId": ""
   },
   "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Expressions"
+    ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
@@ -27,7 +31,7 @@
         "Args": {
           "formatter": {
             "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-            "template": "{ {timestamp: @t, level: @l, message: @m, ..@p} }\n"
+            "template": "{@t: @t, @l: @l, @m: @m, ..@p}\n"
           }
         }
       }


### PR DESCRIPTION
## Description
This PR fixes the logging issue where application logs were not appearing in Railway. 

### Changes
- Updated `appsettings.json` to include the `Serilog.Expressions` and `Serilog.Sinks.Console` in the `Using` array.
- Corrected the `ExpressionTemplate` syntax for Serilog.Expressions.

These changes ensure that Serilog correctly initializes the console sink and formats the output in a way that Railway's log collector can pick up.

### Verification
- Manually verified by deploying to the production environment via Railway CLI (`railway up`). Logs are now visible in the Railway dashboard.
- The app remains healthy at `/health`.