### PR TITLE
fix: implement true structured JSON logging for Railway observability

### DIFF
--- a/openspec/changes/fix-railway-logging/design.md
+++ b/openspec/changes/fix-railway-logging/design.md
@@ -1,20 +1,24 @@
 # Design: Railway Logging Configuration Fix
 
 ## Context
-Railway captures logs from stdout. For .NET applications using Serilog, this requires the `Serilog.Sinks.Console` to be correctly configured and the `Serilog.Expressions` formatter to be properly initialized with a valid template.
+Railway captures logs from stdout. If the output is a JSON object, Railway automatically parses it and populates the log entry's "Attributes".
 
 ## Goals
 - Ensure all application logs are visible in the Railway dashboard.
-- Ensure logs are readable and correctly formatted.
+- Ensure logs are fully structured (JSON) so that custom properties (e.g. `recipient`) are indexed by Railway.
 
 ## Decisions
 ### 1. Mandatory 'Using' Block
-Add `Serilog.Sinks.Console` and `Serilog.Expressions` to the `Using` array in `appsettings.json`.
+Keep `Serilog.Sinks.Console` and `Serilog.Expressions` in the `Using` array to support the expression-based formatter.
 
-### 2. Robust ExpressionTemplate Syntax
-The previously tried template syntax produced mangled output.
-**Decision**: Use the standard bracketed syntax for the `ExpressionTemplate`:
-`"{@t:yyyy-MM-dd HH:mm:ss.fff zzz} [{@l:u3}] {@m}\n{@p}\n{@x}"`
+### 2. Structured JSON Output
+Instead of a human-readable string (which flattens data), we will use an `ExpressionTemplate` that emits a JSON object.
+**Decision**: Use the following template: `{@t, @l, @m, @x, ..@p}\n`
+- `@t`: ISO 8601 Timestamp
+- `@l`: Log Level
+- `@m`: Rendered Message
+- `@x`: Exception details
+- `..@p`: All other properties (flattened into the root object)
 
 ## Risks / Trade-offs
-- Detailed timestamps and levels increase log volume slightly but are essential for troubleshooting.
+- JSON logs are slightly less readable when viewing "Raw Data" manually, but provide vastly superior filtering and dashboarding capabilities in Railway.

--- a/openspec/changes/fix-railway-logging/proposal.md
+++ b/openspec/changes/fix-railway-logging/proposal.md
@@ -1,13 +1,12 @@
-# Change: Fix Railway Logging Observability
+# Change: Fix Railway Logging Observability (Phase 3: True Structured Logging)
 
 ## Why
-Currently, application logs are not appearing or are unreadable in the Railway dashboard. 
-1. Missing logs: Due to missing `Serilog.Expressions` and `Serilog.Sinks.Console` in the `Using` configuration.
-2. Unreadable logs: The `ExpressionTemplate` syntax was being logged literally or mangled (e.g., ` @A, @l: @l, @21: @21, ..@p`).
+Currently, application logs are visible in Railway (Phase 1/2), but they are logged as plain text strings. This prevents Railway from indexing the "Attributes" (structured data like `recipient`, `subject`, etc.), making advanced filtering and observability impossible. We need to output logs in a JSON format that Railway's log collector can natively parse.
 
 ## What Changes
 - Updated `appsettings.json` to include mandatory Serilog assemblies in the `Using` property.
-- Fixed the `ExpressionTemplate` syntax to use a robust format: `"{@t:yyyy-MM-dd HH:mm:ss.fff zzz} [{@l:u3}] {@m}\n{@p}\n{@x}"`.
+- Fixed the `ExpressionTemplate` syntax to output a clean JSON object for every log entry.
+- Ensured structured data is preserved so it appears in Railway's "Attributes" tab.
 
 ## Impact
 - **Affected specs**: `backend-notification-service`

--- a/openspec/changes/fix-railway-logging/tasks.md
+++ b/openspec/changes/fix-railway-logging/tasks.md
@@ -1,10 +1,10 @@
 # Tasks: Fix Railway Logging
 
 ## 1. Implementation
-- [x] 1.1 Update `appsettings.json` with corrected Serilog configuration (add `Using`).
-- [x] 1.2 Update `appsettings.json` with simplified and robust `ExpressionTemplate`.
-- [x] 1.3 Verify locally that logs are correctly formatted and evaluated.
+- [x] 1.1 Update `appsettings.json` with Serilog `Using` configuration.
+- [x] 1.2 Update `appsettings.json` to output structured JSON using `ExpressionTemplate`.
+- [x] 1.3 Verify locally that logs are valid JSON objects and contain all custom properties.
 
 ## 2. Validation
 - [ ] 2.1 Deploy to Railway.
-- [ ] 2.2 Confirm logs are readable and formatted in the Railway dashboard.
+- [ ] 2.2 Confirm that logs appear in the Railway dashboard with indexed "Attributes" (verifying structured logging).

--- a/src/backend/notification-service/NotificationService/appsettings.json
+++ b/src/backend/notification-service/NotificationService/appsettings.json
@@ -31,7 +31,7 @@
         "Args": {
           "formatter": {
             "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-            "template": "{@t:yyyy-MM-dd HH:mm:ss.fff zzz} [{@l:u3}] {@m}\n{@x}"
+            "template": "{ {timestamp: @t, level: @l, message: @m, exception: @x, ..@p} }\n"
           }
         }
       }


### PR DESCRIPTION
## Summary
Implement True Structured JSON Logging for Railway Observability

## Why
While previous fixes ensured logs were visible and human-readable, they were still being output as plain text strings. This prevented Railway (and other log collectors) from parsing the structured data (properties like attributes, exception details, etc.), limiting observability capabilities like filtering by specific fields.

## What Changes
- Updated `appsettings.json` `ExpressionTemplate` to output a valid JSON object for every log entry.
- Keys are explicitly mapped to standard names: `timestamp`, `level`, `message`, `exception`.
- All other structured properties are included via `..@p`.

## Tasks
Implementation tasks completed. Verification pending deployment.

## Affected Specifications
- `backend-notification-service`: logging requirement refines to structured JSON output.

Relates to #88, #90