### PR TITLE
fix: standardize on Serilog Compact JSON for reliable observability

### DIFF
--- a/openspec/changes/fix-railway-logging/design.md
+++ b/openspec/changes/fix-railway-logging/design.md
@@ -1,24 +1,21 @@
-# Design: Railway Logging Configuration Fix
+# Design: Railway Logging Configuration Fix (Phase 4)
 
 ## Context
-Railway captures logs from stdout. If the output is a JSON object, Railway automatically parses it and populates the log entry's "Attributes".
+Railway captures logs from stdout. To enable "True Structured Logging", the application must emit valid, standard JSON that the platform's log collector recognizes and parses.
 
 ## Goals
 - Ensure all application logs are visible in the Railway dashboard.
-- Ensure logs are fully structured (JSON) so that custom properties (e.g. `recipient`) are indexed by Railway.
+- Ensure logs are fully structured (JSON) so that custom properties (e.g., `recipient`, `ProviderCount`) are indexed.
+- Eliminate "double-encoded" JSON strings in the message field.
 
 ## Decisions
-### 1. Mandatory 'Using' Block
-Keep `Serilog.Sinks.Console` and `Serilog.Expressions` in the `Using` array to support the expression-based formatter.
+### 1. Use Standard Compact JSON Formatter
+Switch from `ExpressionTemplate` to `Serilog.Formatting.Compact.RenderedCompactJsonFormatter`.
+- **Why**: It is the industry standard for container logging (CLEF). It handles exceptions, rendering, and property serialization robustly without manual template errors.
+- **Dependency**: Requires `Serilog.Formatting.Compact` package.
 
-### 2. Structured JSON Output
-Instead of a human-readable string (which flattens data), we will use an `ExpressionTemplate` that emits a JSON object.
-**Decision**: Use the following template: `{@t, @l, @m, @x, ..@p}\n`
-- `@t`: ISO 8601 Timestamp
-- `@l`: Log Level
-- `@m`: Rendered Message
-- `@x`: Exception details
-- `..@p`: All other properties (flattened into the root object)
+### 2. Mandatory 'Using' Block
+Keep `Serilog.Sinks.Console` in `Using`. (`Serilog.Expressions` is no longer strictly needed for formatting but kept if other config relies on it).
 
 ## Risks / Trade-offs
-- JSON logs are slightly less readable when viewing "Raw Data" manually, but provide vastly superior filtering and dashboarding capabilities in Railway.
+- Log keys will be shortened (`@t` for timestamp, `@m` for message, etc.). This makes raw text slightly harder for humans to read but is optimized for machine parsing and storage. Railway's attribute viewer should map these or at least display them clearly.

--- a/openspec/changes/fix-railway-logging/proposal.md
+++ b/openspec/changes/fix-railway-logging/proposal.md
@@ -1,16 +1,17 @@
-# Change: Fix Railway Logging Observability (Phase 3: True Structured Logging)
+# Change: Fix Railway Logging Observability (Phase 4: Standard Compact JSON)
 
 ## Why
-Currently, application logs are visible in Railway (Phase 1/2), but they are logged as plain text strings. This prevents Railway from indexing the "Attributes" (structured data like `recipient`, `subject`, etc.), making advanced filtering and observability impossible. We need to output logs in a JSON format that Railway's log collector can natively parse.
+Previous attempts at structured logging using manual `ExpressionTemplate` resulted in "double-JSON" issues in Railway and questionable reliability. To verify true structured logging and ensure industry-standard interoperability, we are switching to the official `Serilog.Formatting.Compact` formatter.
 
 ## What Changes
-- Updated `appsettings.json` to include mandatory Serilog assemblies in the `Using` property.
-- Fixed the `ExpressionTemplate` syntax to output a clean JSON object for every log entry.
-- Ensured structured data is preserved so it appears in Railway's "Attributes" tab.
+- Added `Serilog.Formatting.Compact` package to `NotificationService`.
+- Updated `appsettings.json` to use `Serilog.Formatting.Compact.RenderedCompactJsonFormatter`.
+- This ensures logs are emitted as robust, standard CLEF (Compact Log Event Format) JSON, which is widely supported and reliable in containerized environments.
 
 ## Impact
 - **Affected specs**: `backend-notification-service`
 - **Affected code**: `src/backend/notification-service/NotificationService/appsettings.json`
+- **Dependencies**: Added `Serilog.Formatting.Compact`
 
 ## Linked Issue
 Relates to #88, #90

--- a/openspec/changes/fix-railway-logging/tasks.md
+++ b/openspec/changes/fix-railway-logging/tasks.md
@@ -2,9 +2,10 @@
 
 ## 1. Implementation
 - [x] 1.1 Update `appsettings.json` with Serilog `Using` configuration.
-- [x] 1.2 Update `appsettings.json` to output structured JSON using `ExpressionTemplate`.
-- [x] 1.3 Verify locally that logs are valid JSON objects and contain all custom properties.
+- [x] 1.2 Add `Serilog.Formatting.Compact` package.
+- [x] 1.3 Update `appsettings.json` to use `RenderedCompactJsonFormatter`.
+- [x] 1.4 Verify locally that logs are valid Compact JSON (CLEF).
 
 ## 2. Validation
 - [ ] 2.1 Deploy to Railway.
-- [ ] 2.2 Confirm that logs appear in the Railway dashboard with indexed "Attributes" (verifying structured logging).
+- [ ] 2.2 Confirm that logs are parsed correctly and attributes are indexed.

--- a/src/backend/notification-service/NotificationService/appsettings.json
+++ b/src/backend/notification-service/NotificationService/appsettings.json
@@ -29,10 +29,7 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": {
-            "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-            "template": "{ {timestamp: @t, level: @l, message: @m, exception: @x, ..@p} }\n"
-          }
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
         }
       }
     ],


### PR DESCRIPTION
## Summary
Implement Phase 4: Standard Compact JSON Formatter

## Why
Previous iterations using manual `ExpressionTemplate` resulted in double-encoded JSON strings in Railway logs, preventing true structured observability. We are standardizing on `Serilog.Formatting.Compact` (CLEF) to ensure robust, machine-parsable logging.

## What Changes
- **Dependency**: Added `Serilog.Formatting.Compact` to `NotificationService.csproj`.
- **Config**: Updated `appsettings.json` to use `Serilog.Formatting.Compact.RenderedCompactJsonFormatter`.
- **Outcome**: Logs are now emitted as standard CLEF JSON objects.

## Tasks
1. Implementation (Completed)
   - Added package.
   - Updated config.
   - Verified local output.

2. Validation (Pending Deployment)
   - Verify Railway parses top-level JSON attributes independent of the message field.

Relates to #88, #90